### PR TITLE
Remove old executions from installation test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<tycho.version>2.4.0</tycho.version>
-		<updatesite.eclipse.base>https://download.eclipse.org/releases/</updatesite.eclipse.base>
+		<updatesite.eclipse.base>https://ftp.fau.de/eclipse/releases</updatesite.eclipse.base>
 		<updatesite.palladio>https://updatesite.palladio-simulator.com/palladio-build-updatesite/nightly/</updatesite.palladio>
 	</properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<name>Installation Test</name>
 
 	<properties>
-		<tycho.version>2.3.0</tycho.version>
+		<tycho.version>2.4.0</tycho.version>
 		<updatesite.eclipse.base>https://ftp.fau.de/eclipse/releases</updatesite.eclipse.base>
 		<updatesite.palladio>https://updatesite.palladio-simulator.com/palladio-build-updatesite/nightly/</updatesite.palladio>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -113,68 +113,6 @@
 								<work>${project.build.directory}/2021-09_work</work>
 							</configuration>
 						</execution>
-						
-						<execution>
-							<id>2021-03</id>
-							<goals>
-								<goal>eclipse-run</goal>
-							</goals>
-							<phase>package</phase>
-							<configuration>
-								<repositories>
-									<repository>
-										<id>Eclipse</id>
-										<layout>p2</layout>
-										<url>${updatesite.eclipse.base}/2021-03/</url>
-									</repository>
-								</repositories>
-								<applicationsArgs>
-									<args>-application</args>
-									<args>org.eclipse.equinox.p2.director</args>
-									<args>-repository</args>
-									<args>${updatesite.palladio},${updatesite.eclipse.base}/2021-03/</args>
-									<args>-installIU</args>
-									<!-- information about the installation query: https://wiki.eclipse.org/Equinox/p2/Query_Language_for_p2 -->
-									<args>'Q:everything.select(y | everything.select(x | x.properties ~= filter("(org.eclipse.equinox.p2.type.category=true)") &amp;&amp; x.id ~= /*palladio*/).collect(x | x.requirements).flatten().exists(r | y ~= r))'</args>
-									<args>-debug</args>
-									<args>-consoleLog</args>
-									<args>-destination</args>
-									<args>${project.build.directory}/2021-03</args>
-								</applicationsArgs>
-								<work>${project.build.directory}/2021-03_work</work>
-							</configuration>
-						</execution>
-
-						<execution>
-							<id>2021-06</id>
-							<goals>
-								<goal>eclipse-run</goal>
-							</goals>
-							<phase>package</phase>
-							<configuration>
-								<repositories>
-									<repository>
-										<id>Eclipse</id>
-										<layout>p2</layout>
-										<url>${updatesite.eclipse.base}/2021-06/</url>
-									</repository>
-								</repositories>
-								<applicationsArgs>
-									<args>-application</args>
-									<args>org.eclipse.equinox.p2.director</args>
-									<args>-repository</args>
-									<args>${updatesite.palladio},${updatesite.eclipse.base}/2021-06/</args>
-									<args>-installIU</args>
-									<!-- information about the installation query: https://wiki.eclipse.org/Equinox/p2/Query_Language_for_p2 -->
-									<args>'Q:everything.select(y | everything.select(x | x.properties ~= filter("(org.eclipse.equinox.p2.type.category=true)") &amp;&amp; x.id ~= /*palladio*/).collect(x | x.requirements).flatten().exists(r | y ~= r))'</args>
-									<args>-debug</args>
-									<args>-consoleLog</args>
-									<args>-destination</args>
-									<args>${project.build.directory}/2021-06</args>
-								</applicationsArgs>
-								<work>${project.build.directory}/2021-06_work</work>
-							</configuration>
-						</execution>
 
 					</executions>
 				</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 							<args>-Xmx1024m</args>
 						</jvmArgs>
 						<environmentVariables>
-							<eclipse.p2.mirrors>false</eclipse.p2.mirrors>
+							<eclipse.p2.mirrors>true</eclipse.p2.mirrors>
 						</environmentVariables>
 						<dependencies>
 							<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<properties>
 		<tycho.version>2.4.0</tycho.version>
-		<updatesite.eclipse.base>https://ftp.fau.de/eclipse/releases</updatesite.eclipse.base>
+		<updatesite.eclipse.base>https://download.eclipse.org/releases/</updatesite.eclipse.base>
 		<updatesite.palladio>https://updatesite.palladio-simulator.com/palladio-build-updatesite/nightly/</updatesite.palladio>
 	</properties>
 


### PR DESCRIPTION
Execution environments older than the currently planned release for 2021-09 are removed, as most other projects are updated to 2021-09 already.